### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh		text eol=lf


### PR DESCRIPTION
Forcing line-endings to unix style for *.sh scripts to ensure correct execution of startup scripts when running on Windows hosts